### PR TITLE
fix warnings

### DIFF
--- a/src/components/base/link/Link.js
+++ b/src/components/base/link/Link.js
@@ -23,7 +23,9 @@ export default function Link({
   dataCy = "link",
   className = "",
   tabIndex = "0",
+  tag = "a",
 }) {
+  const Tag = tag;
   // assign given border options to default border options
   // border = { top: false, bottom: true, ...border };
 
@@ -32,7 +34,7 @@ export default function Link({
     const animationClass = !!border ? styles.border : "";
 
     children = (
-      <a
+      <Tag
         data-cy={dataCy}
         target={target}
         onFocus={onFocus}
@@ -44,7 +46,7 @@ export default function Link({
         {border.bottom && (
           <AnimationLine keepVisible={!!border.bottom.keepVisible} />
         )}
-      </a>
+      </Tag>
     );
   }
 
@@ -92,4 +94,5 @@ Link.propTypes = {
     }),
   ]),
   tabIndex: PropTypes.string,
+  tag: PropTypes.oneOf(["a", "span"]),
 };

--- a/src/components/base/link/Link.module.css
+++ b/src/components/base/link/Link.module.css
@@ -2,6 +2,7 @@
   color: var(--mine-shaft);
   text-decoration: none;
   text-decoration-color: var(--blue);
+  cursor: pointer;
 }
 
 .border {

--- a/src/components/header/Header.js
+++ b/src/components/header/Header.js
@@ -78,7 +78,6 @@ function Header({ className = "" }) {
             <Col xs={2}>
               <Link
                 href="/"
-                a={false}
                 dataCy={cyKey({
                   name: "logo",
                   prefix: "header",

--- a/src/components/search/result/Result.js
+++ b/src/components/search/result/Result.js
@@ -100,6 +100,7 @@ function ResultRow({ data }) {
                     }}
                     key={material.materialType}
                     tabIndex="-1"
+                    tag="span"
                   >
                     <Text type="text4">{material.materialType}</Text>
                   </Link>


### PR DESCRIPTION
- der må ikke være a indeni a, derfor har jeg givet mulighed for at man kan bruge en span i stedet for a. Dette bruges i søgeresultat
- header-actions får en a omkring sig - det virker ikke til at det ødelægger noget? Men ellers sig til