### PR TITLE
check for null data & 500 spacing

### DIFF
--- a/src/components/work/details/Details.js
+++ b/src/components/work/details/Details.js
@@ -177,7 +177,8 @@ export default function Wrap(props) {
     }) || manifestations?.[0];
 
   // attach relations for manifestation to display
-  manifestationByMaterialType.relations = groupedRelations;
+  if (manifestationByMaterialType)
+    manifestationByMaterialType.relations = groupedRelations;
 
   return (
     <Details

--- a/src/components/work/details/details.utils.js
+++ b/src/components/work/details/details.utils.js
@@ -705,7 +705,7 @@ export function fieldsForRows(manifestation, work, context) {
           value:
             manifestation?.audience?.let ||
             manifestation?.audience?.lix ||
-            !isEmpty(manifestation.audience.generalAudience)
+            !isEmpty(manifestation.audience?.generalAudience)
               ? manifestation.audience
               : null,
           jsxParser: RenderLitteratureAudience,
@@ -765,7 +765,7 @@ export function fieldsForRows(manifestation, work, context) {
       {
         creatorsfromdescription: {
           label: Translate({ ...context, label: "creatorsfromdescription" }),
-          value: manifestation?.creatorsFromDescription.join("; ") || [],
+          value: manifestation?.creatorsFromDescription?.join("; ") || [],
         },
       },
     ],

--- a/src/components/work/overview/Overview.js
+++ b/src/components/work/overview/Overview.js
@@ -232,14 +232,13 @@ export function OverviewError() {
  */
 export default function Wrap({ workId, type, onTypeChange, login }) {
   const user = useUser();
-
   const fbiWork = useData(workFragments.overviewWork({ workId }));
 
   if (fbiWork.isLoading) {
     return <OverviewSkeleton isSlow={fbiWork.isSlow} />;
   }
 
-  if (fbiWork.error || fbiWork.error) {
+  if (fbiWork.error) {
     return <OverviewError />;
   }
 

--- a/src/components/work/page/Page.js
+++ b/src/components/work/page/Page.js
@@ -22,6 +22,9 @@ import Parts from "../parts";
 import Anchor from "@/components/base/anchor";
 import min from "lodash/min";
 import { AnchorsEnum } from "@/lib/enums";
+import { useData } from "@/lib/api/api";
+import * as workFragments from "@/lib/api/work.fragments";
+import Custom404 from "@/pages/404";
 
 /**
  * The work page React component
@@ -38,6 +41,7 @@ export default function WorkPage({ workId, onTypeChange, login, type }) {
   const router = useRouter();
   const mainRef = useRef();
   const [containerWidth, setContainerWidth] = useState();
+  const fbiWork = useData(workFragments.overviewWork({ workId }));
 
   useEffect(() => {
     // TODO: Make a more elegant solution, when someone has an idea.
@@ -56,6 +60,10 @@ export default function WorkPage({ workId, onTypeChange, login, type }) {
       };
     }
   }, [workId, login, type]);
+
+  if (!fbiWork.isLoading && fbiWork.data.work === null) {
+    return <Custom404 />;
+  }
 
   return (
     <main

--- a/src/pages/500.js
+++ b/src/pages/500.js
@@ -18,7 +18,7 @@ export default function Custom500() {
           {Translate({
             context: "errorpages",
             label: "500_internal_server_error_description",
-          })}
+          })}{" "}
           <Link
             href={Translate({
               context: "errorpages",


### PR DESCRIPTION
Lidt sjov fejl 
Når vi henter work data får vi ikke fejl på at den ikke eksistere, istedet er work=null 
Fejlen skete kun på materiale siden - ellers virker 404 som den skal (da den altid tror materiale siden eksistere)

Ved at tjekke for data i work page kan vi vise 404 siden på en lidt manuel måde. 